### PR TITLE
Condition Callback 

### DIFF
--- a/src/components/ControlledForm/FollowUpField/FollowUpField.js
+++ b/src/components/ControlledForm/FollowUpField/FollowUpField.js
@@ -1,10 +1,6 @@
 import React from "react";
 import { useFormContext } from "react-hook-form";
-import {
-  getFollowUp,
-  isConditionMet,
-  hasFollowUp,
-} from "./FollowUpField.utils";
+import { getFollowUp, hasFollowUp } from "./FollowUpField.utils";
 
 export const renderFollowUpFields = (fields = []) =>
   fields.map(({ Component, ...props }, index) => (
@@ -24,11 +20,9 @@ export const renderFollowUpFields = (fields = []) =>
 const FollowUpField = ({ fieldName, followUp }) => {
   const { watch } = useFormContext();
   const { condition, fields } = followUp || {};
-
   const fieldValue = watch(fieldName);
-  const showFollowUpFields = isConditionMet(condition, fieldValue);
 
-  return showFollowUpFields ? renderFollowUpFields(fields) : null;
+  return condition(fieldValue) ? renderFollowUpFields(fields) : null;
 };
 
 export default FollowUpField;

--- a/src/components/ControlledForm/FollowUpField/FollowUpField.utils.js
+++ b/src/components/ControlledForm/FollowUpField/FollowUpField.utils.js
@@ -1,14 +1,5 @@
 import { isNotEmpty } from "../../../utils";
-import { flow, get, isString, isArray, includes, eq } from "lodash/fp";
+import { flow, get } from "lodash/fp";
 
 export const getFollowUp = get("followUp");
 export const hasFollowUp = flow([getFollowUp, isNotEmpty]);
-
-const isMatchingString = (condition, value) =>
-  isString(value) && eq(condition, value);
-
-const isContainedInArray = (condition, value) =>
-  isArray(value) && includes(condition, value);
-
-export const isConditionMet = (condition, value) =>
-  isMatchingString(condition, value) || isContainedInArray(condition, value);

--- a/src/pages/SingleForm/SingleForm.utils.js
+++ b/src/pages/SingleForm/SingleForm.utils.js
@@ -1,0 +1,5 @@
+import { eq, includes } from "lodash/fp";
+
+export const isEqualToNo = eq("no");
+export const isEqualToYes = eq("yes");
+export const isOtherIncluded = includes("other");

--- a/src/pages/SingleForm/fields.js
+++ b/src/pages/SingleForm/fields.js
@@ -4,6 +4,8 @@ import ControlledFieldArray from "../../components/ControlledFieldArray";
 import ControlledCheckBox from "../../components/ControlledCheckBox";
 import ControlledDropdown from "../../components/ControlledDropdown";
 
+import { isEqualToNo, isEqualToYes, isOtherIncluded } from "./SingleForm.utils";
+
 const dropdownOptions = [
   { label: "Please select", disabled: true },
   { value: "GBP", label: "GBP" },
@@ -36,7 +38,7 @@ export const fields = [
       ],
     },
     followUp: {
-      condition: "other",
+      condition: isOtherIncluded,
       fields: [
         {
           label: "Other Options...",
@@ -84,7 +86,7 @@ export const fields = [
       ],
     },
     followUp: {
-      condition: "no",
+      condition: isEqualToYes,
       fields: [
         {
           label: "Other Options...",
@@ -105,7 +107,7 @@ export const fields = [
             ],
           },
           followUp: {
-            condition: "no",
+            condition: isEqualToNo,
             fields: [
               {
                 label: "Other Name...",


### PR DESCRIPTION
There's so many different types of followUp `condition`'s we're checking now. it can be a string, array or checking several strings in an array. Therefore I'm moving the condition logic out into the `fields` config. 

## PR
This PR converts `condition` to a callback function instead. This creates better inversion control and gives us a lot more control over the condition without cluttering up the FollowUp component. 

```js
    followUp: {
      condition: (value) => {
        return value === "Other"
      },
      fields: [
        {
```

To clean this up a bit I'm using lodash to do this which does the same thing

```js
    followUp: {
      condition: eq('other),
      fields: [
        {
```